### PR TITLE
Make `npm publish` execute before `yarn clean`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "yarn bundle && yarn copy",
     "prebuild": "yarn clean",
     "version": "npm run build && git add .",
-    "postversion": "git push && git push --tags && yarn clean && npm publish"
+    "postversion": "git push && git push --tags && npm publish && yarn clean"
   },
   "repository": "git@github.com:chris-pearce/backpack.css.git",
   "author": "Chris Pearce <hello@cjpearce.com>",


### PR DESCRIPTION
The `lib` folder wasn't making it into the NPM package as `yarn clean` was running before `npm publish` 🤪.